### PR TITLE
Disable Kafka auto topic creation and add init service

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -16,7 +16,7 @@ services:
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_LOG_DIRS: /var/lib/kafka/data
-      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
     volumes:
       - kafka-data:/var/lib/kafka/data
     healthcheck:
@@ -25,6 +25,28 @@ services:
       timeout: 10s
       retries: 5
       start_period: 30s
+
+  kafka-init:
+    image: apache/kafka:4.1.1
+    container_name: kafka-init
+    depends_on:
+      kafka:
+        condition: service_healthy
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -eu
+        for topic in inventory.reservation.requests inventory.reservation.results; do
+          /opt/kafka/bin/kafka-topics.sh \
+            --bootstrap-server kafka:9092 \
+            --create \
+            --if-not-exists \
+            --topic "$$topic" \
+            --partitions 1 \
+            --replication-factor 1
+        done
+    restart: "no"
+
   inventory-postgres:
     container_name: inventory-postgres
     image: postgres:17-alpine
@@ -62,6 +84,8 @@ services:
         condition: service_healthy
       kafka:
         condition: service_healthy
+      kafka-init:
+        condition: service_completed_successfully
 
   order-db:
     image: postgres:17-alpine
@@ -85,6 +109,8 @@ services:
     depends_on:
       kafka:
         condition: service_healthy
+      kafka-init:
+        condition: service_completed_successfully
       order-db:
         condition: service_healthy
     environment:


### PR DESCRIPTION
- KAFKA_AUTO_CREATE_TOPICS_ENABLE を "false" に変更
- 起動時にトピックを作成する kafka-init サービスを追加
  - inventory.reservation.requests
  - inventory.reservation.results
  - partitions=1 / replication-factor=1、--if-not-exists で冪等
- inventory / order-service の depends_on に kafka-init: service_completed_successfully を追加し、トピック作成完了後に起動するように