### PR TITLE
fix(sprint0): remove duplicate route prefix and simplify README setup steps

### DIFF
--- a/services/inventory/README.md
+++ b/services/inventory/README.md
@@ -11,28 +11,14 @@
 docker compose up -d
 ```
 
-PostgreSQL と Kafka (KRaft) が起動する。Kafka の起動完了は以下で確認できる。
+Inventory Service と PostgreSQL 、 Kafka (KRaft) が起動する。Kafka の起動完了は以下で確認できる。
 
 ```bash
 docker compose ps
-# kafka の Status が healthy になるまで待つ（~30秒）
+# kafka の Status が healthy になるまで待つ
 ```
 
-### 2. DB を初期化
-
-```bash
-# テーブル作成
-docker compose exec -T inventory-postgres \
-  psql -U inventory -d inventory \
-  -f - < services/inventory/db/migrations/001_create_inventories.sql
-
-# 初期データ投入
-docker compose exec -T inventory-postgres \
-  psql -U inventory -d inventory \
-  -f - < services/inventory/db/migrations/002_seed_inventories.sql
-```
-
-初期化済みか確認する場合:
+### 2. DB の中身を確認
 
 ```bash
 docker compose exec inventory-postgres \
@@ -40,26 +26,14 @@ docker compose exec inventory-postgres \
 ```
 
 ```
- id |      name        | count
-----+------------------+-------
-  1 | Tシャツ（M）     |   100
-  2 | Tシャツ（L）     |    80
-  3 | デニムパンツ     |    50
-  4 | スニーカー（26cm）|    30
-  5 | キャップ         |   200
-```
-
-### 3. サービスを起動
-
-
-
-```bash
-cd services/inventory
-go run .
-```
-
-```
-starting inventory service on :8080
+ id |        name        | count
+----+--------------------+-------
+  1 | Tシャツ（M）       |   100
+  2 | Tシャツ（L）       |    80
+  3 | デニムパンツ       |    50
+  4 | スニーカー（26cm） |    30
+  5 | キャップ           |   200
+(5 rows)
 ```
 
 ---

--- a/services/order/README.md
+++ b/services/order/README.md
@@ -51,7 +51,7 @@ PENDING ─→ CONFIRMED   (在庫予約成功)
 
 | 変数名 | デフォルト | 説明 |
 |--------|-----------|------|
-| `DATABASE_URL` | `postgresql://order:password@localhost:5432/order` | PostgreSQL 接続文字列 |
+| `DATABASE_URL` | `postgresql://order:password@localhost:5432/order` | PostgreSQL 接続文字列 | # pragma: allowlist secret
 | `KAFKA_BROKERS` | (必須) | Kafka ブローカーアドレス |
 | `KAFKA_REQUEST_TOPIC` | `inventory.reservation.requests` | 予約リクエストトピック |
 | `KAFKA_RESULT_TOPIC` | `inventory.reservation.results` | 予約結果トピック |
@@ -88,27 +88,13 @@ python main.py
 docker compose up
 ```
 
-### 2. Kafka topic を作成する
-
-初回起動直後は topic がまだ存在せず、consumer / producer が `UNKNOWN_TOPIC_OR_PARTITION` になることがある。
-動作確認の前に、別ターミナルで必要な topic を明示的に作成しておく。
+### 2. Kafka topic の確認
 
 ```bash
-docker exec kafka /opt/kafka/bin/kafka-topics.sh \
-  --bootstrap-server localhost:9092 \
-  --create \
-  --if-not-exists \
-  --topic inventory.reservation.requests \
-  --partitions 1 \
-  --replication-factor 1
-
-docker exec kafka /opt/kafka/bin/kafka-topics.sh \
-  --bootstrap-server localhost:9092 \
-  --create \
-  --if-not-exists \
-  --topic inventory.reservation.results \
-  --partitions 1 \
-  --replication-factor 1
+docker compose exec kafka /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list
+__consumer_offsets
+inventory.reservation.requests
+inventory.reservation.results
 ```
 
 ### 3. 注文を作成する

--- a/services/order/main.py
+++ b/services/order/main.py
@@ -39,7 +39,7 @@ async def run() -> None:
     )
 
     app = FastAPI(title="Order Service")
-    app.include_router(create_router(usecase), prefix="/order")
+    app.include_router(create_router(usecase))
 
     server_config = uvicorn.Config(app, host="0.0.0.0", port=8080, log_level="info")
     server = uvicorn.Server(server_config)


### PR DESCRIPTION
## 概要
Sprint0 の E2E 動作確認を行い、発見した問題を修正しました。
Order サービスのルーティング設定の誤りを直し、自動初期化済みの docker compose 環境に合わせて README を整理しています。

## 変更内容
- **order サービス**: `app.include_router` の重複 `/order` プレフィックスを削除（`prefix="/order"` を除去）
- **inventory README**: 手動 DB 初期化・サービス起動手順を削除し、`docker compose up` 一発で起動する構成に合わせた記述に整理
- **order README**: 手動 Kafka topic 作成手順を削除し、自動作成済み構成に合わせた確認手順に更新
- **order README**: `DATABASE_URL` のデフォルト値に `pragma: allowlist secret` を追加して誤検知を回避

## 動作確認

```bash
# 全サービス起動
docker compose up --build -d

# PostgreSQL の在庫確認（初期データが正しくシードされている）
docker compose exec inventory-postgres \
  psql -U inventory -d inventory -c "SELECT * FROM inventories;"
# id |        name        | count
#----+--------------------+-------
#  1 | Tシャツ（M）       |   100
#  2 | Tシャツ（L）       |    80
#  3 | デニムパンツ       |    50
#  4 | スニーカー（26cm） |    30
#  5 | キャップ           |   200

# Kafka topic の自動作成を確認
docker compose exec kafka /opt/kafka/bin/kafka-topics.sh \
  --bootstrap-server localhost:9092 --list
# __consumer_offsets
# inventory.reservation.requests
# inventory.reservation.results

# 注文作成（ルート修正後の /orders エンドポイントが正常に応答）
curl -s -X POST http://localhost:8081/orders \
  -H "Content-Type: application/json" \
  -d '{"customer_id": "user-123", "items": [{"inventory_id": 1, "quantity": 2}]}' | jq .

# Kafka トピックへのメッセージ発行・受信を確認
docker exec kafka /opt/kafka/bin/kafka-console-consumer.sh \
  --bootstrap-server localhost:9092 \
  --topic inventory.reservation.requests --from-beginning

docker exec kafka /opt/kafka/bin/kafka-console-consumer.sh \
  --bootstrap-server localhost:9092 \
  --topic inventory.reservation.results --from-beginning

# 注文ステータスの確認
curl -s http://localhost:8081/orders/<注文ID> | jq .status
```

## 確認事項
- `prefix="/order"` 削除によりエンドポイントが `/orders` になっています。他のクライアントコードで `/order/orders` を呼んでいる箇所がないか確認ください